### PR TITLE
Two small Bugfixes & Workaround for south

### DIFF
--- a/facebook/feincms/utils.py
+++ b/facebook/feincms/utils.py
@@ -1,4 +1,5 @@
 from feincms.module.page.models import Page
+from facebook.modules.profile.application.utils import get_app_dict
 
 def get_application_from_request(request):
     try:
@@ -20,7 +21,7 @@ def get_tab_url_from_request(request):
     except Page.DoesNotExist:
         return None
 
-    fb_app = getattr(page, 'facebook_application', None)
+    fb_app = get_app_dict(getattr(page, 'facebook_application', None))
     fb_page = getattr(page, 'facebook_page', None)
 
     if fb_page and fb_app:
@@ -28,6 +29,6 @@ def get_tab_url_from_request(request):
             separator = '&'
         else:
             separator = '?'
-        return u'%s%ssk=app_%s' % (fb_page.facebook_link, separator, fb_app.id)
+        return u'%s%ssk=app_%s' % (fb_page.facebook_link, separator, fb_app['ID'])
     else:
         return None

--- a/facebook/models.py
+++ b/facebook/models.py
@@ -1,0 +1,20 @@
+"""
+    Dummy model to get old references to the new structured models.
+    Needed by south
+
+    possible rewrite with dynamic imports http://www.diveintopython.net/functional_programming/dynamic_import.html
+"""
+
+from django.conf import settings
+
+if 'facebook.modules.profile.page' in settings.INSTALLED_APPS:
+    from facebook.modules.profile.page.models import Page
+
+if 'facebook.modules.profile.user' in settings.INSTALLED_APPS:
+    from facebook.modules.profile.user.models import User, TestUser
+
+if 'facebook.modules.profile.event' in settings.INSTALLED_APPS:
+    from facebook.modules.profile.event.models import Event
+
+if 'facebook.modules.profile.application' in settings.INSTALLED_APPS:
+    from facebook.modules.profile.application.models import Request

--- a/facebook/modules/profile/page/admin.py
+++ b/facebook/modules/profile/page/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import ugettext_lazy as _
 
 from facebook.modules.base import AdminBase
 


### PR DESCRIPTION
The cause of the bugfixes can be read in the code.

The South Workaround is explained here:
To migrate an old project to this new branch & approach, its best to use south. but south expects a models.py in the "app_label" root. if there is no models.py, it fails. but because we set the app_label of all modules to 'facebook' to have all under one hood in the admin, we can't migrate them granular.

with this workaround, south finds all the models who are activated in settings.py and we can preserve the structured approach. maybe it is a plus to have all activated models accessible via facebook.models.

but south compatibility is not discussed to the end with this workaround. the best will be, that every module has its own south migrations directory, where all migrations are done. but at this point, i dont know how to achieve this.
