### PR TITLE
Bugfixes & Security

### DIFF
--- a/facebook/context_processors.py
+++ b/facebook/context_processors.py
@@ -11,7 +11,10 @@ def application_settings(request):
              'FACEBOOK_CANVAS_URL' : firstapp['CANVAS-URL']}
     
 def facebook_config(request):
-    return {'facebook' : request.session['facebook']}
+    if 'facebook' in request.session:
+        return {'facebook' : request.session['facebook']}
+    else:
+        return {'facebook' : False }
 
 def session_without_cookies(request):
     """ simple helper to use sessions without cookies """

--- a/facebook/feincms/middleware.py
+++ b/facebook/feincms/middleware.py
@@ -18,4 +18,4 @@ class PreventForeignApp(object):
 
             if signed_request['page']['id'] != str(facebook_page.id):
                 destination = '%s&app_data=%s' % (get_tab_url_from_request(request), request.path_info)
-                return render_to_response('redirecter.html', {'destination' : destination})
+                return render_to_response('facebook/redirecter.html', {'destination' : destination})

--- a/facebook/middleware.py
+++ b/facebook/middleware.py
@@ -109,7 +109,13 @@ class Redirect2AppDataMiddleware(object):
         try:
             # only execute first time (Facebook will POST the tab with signed_request parameter)
             if request.method == 'POST' and request.POST.has_key('signed_request'):
-                target_url = request.session['facebook']['signed_request']['app_data']
+                app_data = request.session['facebook']['signed_request']['app_data']
+
+                if '//' in app_data or '..' in app_data:
+                    logger.warn('Possible defacing in app_data detected: %s' % app_data)
+                    return None
+
+                target_url = '%s%s' % (request.META['SCRIPT_NAME'], app_data)
                 logger.debug('got target url: %s' % target_url)
                 del request.session['facebook']['signed_request']['app_data']
                 request.session.modified = True


### PR DESCRIPTION
Only small changes:
- facebook_config context processor crashed once. so it will now check for facebook in the session
- feincms middleware did not use the new path for the redirecter.html template
- securing redirect to app data. check for possible defacings.
