### PR TITLE
Deprecate csrfViewMiddleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .*.swp
 \#*#
 *.mo
-/.DS_Store
+.DS_Store
 .settings
 .project
 .pydevproject

--- a/docs/Release_Notes.rst
+++ b/docs/Release_Notes.rst
@@ -6,19 +6,20 @@ Due to the high update cycle there are no version numbers. The release notes are
 the date the change has been added to the repo.
 
 
+June 22, 2012
+=============
+
+ * Move game views to game module
+ * custom CSRF middleware is no longer necessary. Just put SignedRequestMiddleware in between SessionMiddleware
+   and Django's csrfViewMiddleware.
 
 
 
 May 19, 2012
 ============
 
-Breaking Changes
-----------------
  * Add field '_access_token_expires' to fb.Page model.
  * Add field 'created' to fb.Post model.
-
-New Featues
------------
  * Add insight link to page
  * Working deauthorize callback with preview
  * docs update

--- a/docs/Release_Notes.rst
+++ b/docs/Release_Notes.rst
@@ -1,0 +1,24 @@
+===================================
+Django-facebook-graph Release Notes
+===================================
+
+Due to the high update cycle there are no version numbers. The release notes are structured by
+the date the change has been added to the repo.
+
+
+
+
+
+May 19, 2012
+============
+
+Breaking Changes
+----------------
+ * Add field '_access_token_expires' to fb.Page model.
+ * Add field 'created' to fb.Post model.
+
+New Featues
+-----------
+ * Add insight link to page
+ * Working deauthorize callback with preview
+ * docs update

--- a/docs/feincms.rst
+++ b/docs/feincms.rst
@@ -1,0 +1,39 @@
+Using django-facebook-graph with FeinCMS
+========================================
+
+The facebook page extension allows you to have several Facebook apps assigned to
+different FeinCMS pages. This way you can have multiple tabs on your Facebook page
+and manage them in a single admin.
+
+
+Facebook Application Extension
+------------------------------
+
+In your models.py add::
+
+    from facebook.feincms.extensions import facebook_application
+
+    Page.register_extension(facebook_application)
+
+
+Make sure you have installed the fb.Page module
+In the FeinCMS admin add your Facebook pages. The FeinCMS pages have two additional fields
+for the facebook app and page. If the page is set, the content can only be displayed within
+that page.
+The app is used to decrypt the signed request.
+
+
+Content Type Extension
+----------------------
+
+This is a monkey-patch for FeinCMS contents. It adds two fields: render_like and app_installed.
+It allows to control if a content type is displayed whether a user has liked a page or not
+or has installed the app.
+
+Because it's a monkey-patch the order of import is important (models.py)::
+
+    from feincms.content.richtext.models import RichTextContent
+    from facebook.feincms.extensions import content_type_extension
+
+    content_type_extension(RichTextContent)
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents:
    reference
    examples
    feincms
+   release_notes
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents:
    getting-started
    reference
    examples
+   feincms
 
 
 Indices and tables

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,15 +30,22 @@ The ``SignedRequestMiddleware`` is the main middleware that stores the signed
 request in a special session object and allows your app to access it. Most
 of the framework expects this middleware to be installed to function correctly.
 
-Because Facebook calls your page initially with POST, you need a custom csrf middleware
-that lets facebook pass.
+Because Facebook calls your page initially with POST, you need to pay attention
+to put the ``SignedRequestMiddleware`` before the ``CsrfViewMiddleware`` but after the
+``SessionMiddleware``.
+
+The ``FakeSessionCookieMiddleware`` reads the session key from request.GET. This is
+necessary for Safari 5.0.1 (OSX Leopard) since that browser does not support sessions in
+iFrames. It comes with a template tag, too.
 
 The ``AppRequestMiddleware`` adds some tools to help dealing with app requests::
 
     MIDDLEWARE_CLASSES = (
-        'facebook.csrf.CsrfViewMiddleware',
-        <other middlewares>,
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'facebook.middleware.FakeSessionCookieMiddleware', # for Safari 5.0.1
         'facebook.middleware.SignedRequestMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        <other middlewares>,
         'facebook.middleware.AppRequestMiddleware', # optional.
     )
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,13 +30,18 @@ The ``SignedRequestMiddleware`` is the main middleware that stores the signed
 request in a special session object and allows your app to access it. Most
 of the framework expects this middleware to be installed to function correctly.
 
+Because Facebook calls your page initially with POST, you need a custom csrf middleware
+that lets facebook pass.
+
 The ``AppRequestMiddleware`` adds some tools to help dealing with app requests::
 
     MIDDLEWARE_CLASSES = (
+        'facebook.csrf.CsrfViewMiddleware',
         <other middlewares>,
         'facebook.middleware.SignedRequestMiddleware',
-        'facebook.middleware.AppRequestMiddleware',
+        'facebook.middleware.AppRequestMiddleware', # optional.
     )
+
 
 
 Add the URLs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -113,12 +113,13 @@ Add this to the bottom of your base template in the scripts section::
 
     <div id="fb-root"></div>
     <script type="text/javascript">
-    (function() {
-        var e = document.createElement('script'); e.async = true;
-        e.src = document.location.protocol +
-        '//connect.facebook.net/de_DE/all.js';
-        document.getElementById('fb-root').appendChild(e);
-    }());
+    (function(d){
+         var js, id = 'facebook-jssdk', ref = d.getElementsByTagName('script')[0];
+         if (d.getElementById(id)) {return;}
+         js = d.createElement('script'); js.id = id; js.async = true;
+         js.src = "//connect.facebook.net/en_US/all.js";
+         ref.parentNode.insertBefore(js, ref);
+       }(document));
     </script>
 
 The Facebook script is loaded asynchronously. Therefore you have to use the FQ,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -108,12 +108,13 @@ Add this to the bottom of your base template in the scripts section::
 
     <div id="fb-root"></div>
     <script type="text/javascript">
-    (function() {
-        var e = document.createElement('script'); e.async = true;
-        e.src = document.location.protocol +
-        '//connect.facebook.net/de_DE/all.js';
-        document.getElementById('fb-root').appendChild(e);
-    }());
+    (function(d){
+         var js, id = 'facebook-jssdk', ref = d.getElementsByTagName('script')[0];
+         if (d.getElementById(id)) {return;}
+         js = d.createElement('script'); js.id = id; js.async = true;
+         js.src = "//connect.facebook.net/en_US/all.js";
+         ref.parentNode.insertBefore(js, ref);
+       }(document));
     </script>
 
 The Facebook script is loaded asynchronously. Therefore you have to use the FQ,

--- a/facebook/csrf.py
+++ b/facebook/csrf.py
@@ -14,6 +14,11 @@ logger = logging.getLogger(__name__)
 
 CSRF_KEY_LENGTH = 32
 
+import warnings
+warnings.warn('facebook.csrf.CsrfViewMiddleware is no longer necessary. '
+              'Just make sure the SignedRequestMiddleware gets called before the '
+              'standard django CsrfViewMiddleware.', DeprecationWarning, stacklevel=2)
+
 # CSRF view middleware changed significantly in Django 1.4
 
 if django.VERSION[0]==1 and django.VERSION[1] >= 4:

--- a/facebook/modules/connections/game/views.py
+++ b/facebook/modules/connections/game/views.py
@@ -1,10 +1,11 @@
 #coding=utf-8
-
-from facebook.models import User
-from models import Score
-
 """ Views for game-related task such as getting and settings scores and achievments. """
-from facebook.utils import get_static_graph
+
+from facebook.modules.profile.user.models import User
+from facebook.modules.profile.application.utils import get_app_dict
+from .models import Score
+
+from facebook.graph import get_static_graph
 
 def get_user_score(user_id, graph):
     """If the user has granted your app with the user_games_activity permission then 

--- a/facebook/session.py
+++ b/facebook/session.py
@@ -100,8 +100,12 @@ class FBSession(SessionBase):
             self.access_token = token
             if not expires:
                 expires=datetime.now() + timedelta(hours=1)
-            self.token_expires = expires
-    
+            # Check if there is already a longer lasting token:
+            if isinstance(self.token_expires, datetime) and self.token_expires > expires:
+                pass
+            else:
+                self.token_expires = expires
+
     def _clear_token(self):
         self.access_token = None
         self.user_id = None


### PR DESCRIPTION
custom CSRF middleware is no longer necessary. Just put SignedRequestMiddleware in between SessionMiddleware and Django's csrfViewMiddleware.
